### PR TITLE
Use rko-router for cfp.rubykaigi.org

### DIFF
--- a/rubykaigi.org.lua
+++ b/rubykaigi.org.lua
@@ -15,6 +15,6 @@ cname("yami", router)
 cname("j", router)
 cname("regional", router)
 cname("regional-gh", "ruby-no-kai.github.io.")
-cname("cfp", "rubykaigi-cfp.herokuapp.com.")
+cname("cfp", router)
 
 google_app(_a)


### PR DESCRIPTION
Revert "Point Heroku directly by CNAME cfp"
This reverts commit 9dc8a563be60ad736c501a8937158f0f601580b9.