### PR TITLE
Add records for validating SendGrid Whitelabels of cfp-app

### DIFF
--- a/rubykaigi.org.lua
+++ b/rubykaigi.org.lua
@@ -17,6 +17,11 @@ cname("regional", router)
 cname("regional-gh", "ruby-no-kai.github.io.")
 cname("cfp", router)
 
+-- for SendGrid Whitelabels of cfp-app
+cname("cfp-mail", "u1814470.wl.sendgrid.net")
+cname("s1._domainkey", "s1.domainkey.u1814470.wl.sendgrid.net")
+cname("s2._domainkey", "s2.domainkey.u1814470.wl.sendgrid.net")
+
 -- for Google Apps
 mx(_a, "aspmx.l.google.com", 5)
 mx(_a, "alt1.aspmx.l.google.com", 10)


### PR DESCRIPTION
古い`sendgrid.rubykaigi.org`なCNAMEが残っていましたが、それを最近のSendGridのホワイトラベルのルールに更新することによる影響を読み切れないため、別のサブドメインを立て、SendGridの指示に従って3件のCNAMEを追加しています。