### PR TITLE
Setup records for kaigionrails.org

### DIFF
--- a/kaigionrails.org.lua
+++ b/kaigionrails.org.lua
@@ -3,6 +3,7 @@ a(_a, "185.199.109.153")
 a(_a, "185.199.110.153")
 a(_a, "185.199.111.153")
 
+cname("past", "ruby-no-kai.github.io.")
 cname("22161183", "case-22161183-for-kaigionrails.org-at.google.com.")
 
 mx(_a, "aspmx.l.google.com", 1)

--- a/kaigionrails.org.lua
+++ b/kaigionrails.org.lua
@@ -4,6 +4,7 @@ a(_a, "185.199.110.153")
 a(_a, "185.199.111.153")
 
 cname("past", "ruby-no-kai.github.io.")
+cname("cfp", "fundamental-bedbug-0etq6gplqbbvcenmoum4b7fd.herokudns.com.")
 cname("22161183", "case-22161183-for-kaigionrails.org-at.google.com.")
 
 mx(_a, "aspmx.l.google.com", 1)


### PR DESCRIPTION
- past.kaigionrails.org
    - 過去開催のarchive用
- cfp.klaigionrails.org
    - cfp-app用

となります。