### PR TITLE
Add 2021.kaigionrails.org

### DIFF
--- a/kaigionrails.org.lua
+++ b/kaigionrails.org.lua
@@ -4,6 +4,7 @@ a(_a, "185.199.110.153")
 a(_a, "185.199.111.153")
 
 cname("past", "ruby-no-kai.github.io.")
+cname("2021", "ruby-no-kai.github.io.")
 cname("cfp", "fundamental-bedbug-0etq6gplqbbvcenmoum4b7fd.herokudns.com.")
 cname("22161183", "case-22161183-for-kaigionrails.org-at.google.com.")
 


### PR DESCRIPTION
https://github.com/ruby-no-kai/kaigi-on-rails-2021 を ` 2021.kaigionrails.org` 以下で公開します