### PR TITLE
Add 2022.kaigionrails.github.io

### DIFF
--- a/kaigionrails.org.lua
+++ b/kaigionrails.org.lua
@@ -2,6 +2,7 @@ alias(_a, "mammalian-snail-4nwu8u68e7a4592btwe8ztwq.herokudns.com")
 
 cname("past", "ruby-no-kai.github.io.")
 cname("2021", "ruby-no-kai.github.io.")
+cname("2022", "kaigionrails.github.io.")
 cname("cfp", "fundamental-bedbug-0etq6gplqbbvcenmoum4b7fd.herokudns.com.")
 cname("sponsorships", "immense-lavender-3hnhgmcaijeqiw624c9zohet.herokudns.com.")
 cname("22161183", "case-22161183-for-kaigionrails.org-at.google.com.")


### PR DESCRIPTION
To publish 2022 event page

![image](https://user-images.githubusercontent.com/4487291/169031463-493c6cfc-e2a6-48a4-b64f-7d96429750fa.png)
