### PR TITLE
Add TXT to verify domain by firebase hosting

### DIFF
--- a/kaigionrails.org.lua
+++ b/kaigionrails.org.lua
@@ -15,4 +15,5 @@ mx(_a, "alt4.aspmx.l.google.com", 10)
 mx(_a, "3asytb3b63jfhxl6yijytjtcgxuftk5orfppfpuiaenyeyxratwa.mx-verification.google.com", 15)
 
 txt(_a, "v=spf1 include:mailgun.org ~all", 60)
+txt(_a, "google-site-verification=uhm3OiuP2yukFmkPKleF4l4hc_dmaMwxjJci2oYT2h0", 60)
 txt("pic._domainkey", "k=rsa; p=MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQCusxsCqLjU5gP+3dwvYAb/gVns8zSJOtDE2EM4RF53TbpXfN5lQJ/PJnmmkONu4QQ38ZaU/JOZarpBG359dn6dT6KMzn07Lhlm88FCAGcuWmGcXemzHZewoOWtjcwXjtLXsMmyb2bEWHdsGWPSqYEg9aRLercMPQKGiQJBFaIz2QIDAQAB", 60)


### PR DESCRIPTION
firebase hostingを使用するためにドメインの検証が必要なため、TXTを追加します

![image](https://user-images.githubusercontent.com/4487291/189930320-70afbb36-01d9-4cdb-90fc-34eada5ba427.png)
