### PR TITLE
`kaigionrails.org` の `NS` としてCloudflareのDNSを追加する

### DIFF
--- a/kaigionrails.org.lua
+++ b/kaigionrails.org.lua
@@ -19,3 +19,6 @@ mx(_a, "3asytb3b63jfhxl6yijytjtcgxuftk5orfppfpuiaenyeyxratwa.mx-verification.goo
 txt(_a, "v=spf1 include:mailgun.org ~all", 60)
 txt(_a, "google-site-verification=uhm3OiuP2yukFmkPKleF4l4hc_dmaMwxjJci2oYT2h0", 60)
 txt("pic._domainkey", "k=rsa; p=MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQCusxsCqLjU5gP+3dwvYAb/gVns8zSJOtDE2EM4RF53TbpXfN5lQJ/PJnmmkONu4QQ38ZaU/JOZarpBG359dn6dT6KMzn07Lhlm88FCAGcuWmGcXemzHZewoOWtjcwXjtLXsMmyb2bEWHdsGWPSqYEg9aRLercMPQKGiQJBFaIz2QIDAQAB", 60)
+
+ns(_a, "rajeev.ns.cloudflare.com", 300)
+ns(_a, "ullis.ns.cloudflare.com", 300)


### PR DESCRIPTION
ref https://github.com/ruby-no-kai/official/issues/475

## Cloudflare's configuration
![image](https://user-images.githubusercontent.com/4487291/229467703-2a7523c3-8c19-4db7-9612-8157299fa359.png)
![image](https://user-images.githubusercontent.com/4487291/229467877-3177a3da-6e6b-4980-a078-7dcf86281058.png)

## 懸念事項
LuaDNSのNS recordの設定として zone name ( `_a` )を使用できるのか

http://www.luadns.com/help.html#ns-record

切り戻しが容易なようにTTLを短くしてあります(5分)。